### PR TITLE
Add files via upload

### DIFF
--- a/main.c
+++ b/main.c
@@ -76,9 +76,9 @@ short DataReady;
 void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 {
   /* Prevent unused argument(s) compilation warning */
-  if(htim->Instance==TIM5)							//wenn timer 5 ausgelÃ¶st hat tue folgendes
+  if(htim->Instance==TIM5)							//wenn timer 5 ausgelöst hat tue folgendes
   {
-  DataReady=2;										//flag um rotine auszufÃ¼hren
+HAL_GPIO_TogglePin(GPIOD, GPIO_PIN_15);	//Rückmeldung an User Sensor ist eingeschaltet, blaue LED blinkt
   }
   /* NOTE : This function Should not be modified, when the callback is needed,
             the __HAL_TIM_PeriodElapsedCallback could be implemented in the user file
@@ -123,6 +123,7 @@ int main(void)
   MX_TIM3_Init();
   MX_TIM5_Init();
   /* USER CODE BEGIN 2 */
+
 HAL_TIM_Base_Start_IT(&htim5);
 
 init_L3GD20();
@@ -132,19 +133,16 @@ HAL_TIM_Base_Start_IT(&htim3);
 void Messwert()
 	  {
 
+	 DataReady=0;													//Zurücksetzen des Flag
 
 	 Messwerte_L3GD20(&rollX, &rollY, &rollZ);
 
 	  //HAL_GPIO_WritePin(GPIOD, GPIO_PIN_14,GPIO_PIN_RESET);
 
-	  DataReady=0;													//ZurÃ¼cksetzen des Flag
-
 	  return;
 	  }
 
-
-
-
+DataReady=2;	//Setzen des flag das Daten verfügbar sind, notwendig da der Sensor Interrupt erst nach lesen der Sensor Register wieder "scharf" gemacht wird
   /* USER CODE END 2 */
 
   /* Infinite loop */
@@ -158,7 +156,10 @@ void Messwert()
 		  Messwert();
 	  }
 
-//	In der folgenden Abfrage werden die AusgÃ¤nge geschaltet die die Lampensterung Ã¼bernehmen. Bei der Verwedeten Hardware sind die AusgÃ¤nge zur einfachen kontrolle bereits an LED angeschlossen.
+
+	  /*
+	   * Im folgenden Abschnitt werden die Ausgänge geschaltet. Auf dem verwendeten Board sind die Pins 12 und 14 gleichzeitig LED.
+	   */
 	  if (rollY>1500)
 	  {
 		  HAL_GPIO_WritePin(GPIOD, GPIO_PIN_12,GPIO_PIN_SET);
@@ -398,7 +399,7 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin_1)
 {
   /* Prevent unused argument(s) compilation warning */
 
-	 DataReady=2;	//Setzen des flag das neue Daten verfÃ¼gbar sind
+	 DataReady=2;	//Setzen des flag das neue Daten verfügbar sind
 
   /* NOTE: This function Should not be modified, when the callback is needed,
            the HAL_GPIO_EXTI_Callback could be implemented in the user file


### PR DESCRIPTION
Blinkende blaue LED signalisiert dem user das das Gerät eingeschaltet ist. Logischer Fehler beim rücksetzen des DataReady flag beseitigt.